### PR TITLE
Use string-replace to sync the version and date

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,9 +1,12 @@
 module.exports = function(grunt) {
   require('load-grunt-tasks')(grunt);
 
+  var pkgJson = require('./package.json');
+
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-typescript');
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-string-replace');
 
   grunt.initConfig({
     clean: ['dist'],
@@ -61,6 +64,26 @@ module.exports = function(grunt) {
       }
     },
 
+    'string-replace': {
+      dist: {
+        files: [{
+          cwd: 'src',
+          expand: true,
+          src: ["**/plugin.json"],
+          dest: 'dist'
+        }],
+        options: {
+          replacements: [{
+            pattern: '%VERSION%',
+            replacement: pkgJson.version
+          },{
+            pattern: '%TODAY%',
+            replacement: '<%= grunt.template.today("yyyy-mm-dd") %>'
+          }]
+        }
+      }
+    },
+
     watch: {
       files: ['src/**/*.ts', 'src/**/*.html', 'src/**/*.css', 'src/img/*.*', 'src/plugin.json', 'README.md'],
       tasks: ['default'],
@@ -77,6 +100,7 @@ module.exports = function(grunt) {
     'copy:dist_html',
     'copy:dist_css',
     'copy:dist_img',
-    'copy:dist_statics'
+    'copy:dist_statics',
+    'string-replace'
   ]);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-typescript-template-datasource",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "TypeScript Template Data Source for Grafana. A starter template for creating data sources written in TypeScript for Grafana.",
   "scripts": {
     "build": "grunt",
@@ -21,6 +21,7 @@
     "grunt-contrib-clean": "^1.1.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",
+    "grunt-string-replace": "^1.3",
     "grunt-typescript": "^0.8.0",
     "karma": "^1.7.0",
     "karma-chrome-launcher": "^2.2.0",
@@ -31,6 +32,7 @@
     "karma-systemjs": "^0.16.0",
     "plugin-typescript": "^7.1.0",
     "sinon": "^3.2.1",
-    "systemjs-plugin-css": "^0.1.35"
+    "systemjs-plugin-css": "^0.1.35",
+    "load-grunt-tasks": "^3.5.2"
   }
 }

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -18,8 +18,8 @@
       {"name": "Project site", "url": "https://github.com/yourorg/your-datasource"},
       {"name": "Apache License", "url": "https://github.com/yourorg/your-datasource/blob/master/LICENSE"}
     ],
-    "version": "0.0.1",
-    "updated": "2017-09-28"
+    "version": "%VERSION%",
+    "updated": "%TODAY%"
   },
 
   "dependencies": {


### PR DESCRIPTION
This keeps the package.json version the same as the plugin.json automatically.  It also sets the date to TODAY automatically.

It may be too weird for the template, but i'm posting it here because it has simplified my plugin management